### PR TITLE
Period at a message's end

### DIFF
--- a/ghae/github_api_error.py
+++ b/ghae/github_api_error.py
@@ -1,5 +1,7 @@
 # __all__ declared at the module's end
 
+_PERIOD = '.'
+
 
 class GitHubApiError(Exception):
 	"""
@@ -30,7 +32,12 @@ class GitHubApiError(Exception):
 			+ f"'{self._status}', '{self._req_url}')"
 
 	def __str__(self):
-		return f"[{self._req_url}] {self._status}: {self._message}"\
+		msg = self._message
+
+		if len(msg) > 0 and msg[-1] != _PERIOD:
+			msg += _PERIOD
+
+		return f"[{self._req_url}] {self._status}: {msg}"\
 			+ f" Documentation: {self._doc_url}"
 
 	@property

--- a/ghae/github_api_error.py
+++ b/ghae/github_api_error.py
@@ -30,7 +30,7 @@ class GitHubApiError(Exception):
 			+ f"'{self._status}', '{self._req_url}')"
 
 	def __str__(self):
-		return f"[{self._req_url}] {self._status}: {self._message}."\
+		return f"[{self._req_url}] {self._status}: {self._message}"\
 			+ f" Documentation: {self._doc_url}"
 
 	@property

--- a/ghae/github_api_error.py
+++ b/ghae/github_api_error.py
@@ -1,6 +1,6 @@
 # __all__ declared at the module's end
 
-_PERIOD = '.'
+_PERIOD = "."
 
 
 class GitHubApiError(Exception):


### PR DESCRIPTION
A period is added at the end of a `GitHubApiError`'s message if it lacks one.

Edit: period added only in `GitHubApiError.__str__`.