### PR TITLE
Library `syspathmodif` upgraded to version `1.5.0`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 requests==2.32.3
 pytest==8.3.5
-syspathmodif==1.4.0
+syspathmodif==1.5.0

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -45,9 +45,9 @@ def test_error_detection_erroneous_request():
 		detect_github_api_error(_FAKE_URL, response_data)
 
 	# The GitHubApiError instance
-	e = except_info.value
-	assert e.message == "Not Found"
-	assert e.doc_url\
+	gae = except_info.value
+	assert gae.message == "Not Found"
+	assert gae.doc_url\
 		== "https://docs.github.com/rest/repos/repos#get-a-repository"
-	assert e.status == "404"
-	assert e.req_url == "https://api.github.com/repos/nobody/nothing"
+	assert gae.status == "404"
+	assert gae.req_url == "https://api.github.com/repos/nobody/nothing"

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from syspathmodif import\
-	sp_append,\
+	sp_prepend,\
 	sp_remove
 
 
@@ -17,7 +17,7 @@ _REPO_ROOT = _LOCAL_DIR.parent
 _FAKE_URL = "https://api.github.com/repos/nobody/nothing"
 
 
-sp_append(_REPO_ROOT)
+sp_prepend(_REPO_ROOT)
 from ghae import\
 	GitHubApiError,\
 	detect_github_api_error

--- a/tests/test_error_detection.py
+++ b/tests/test_error_detection.py
@@ -24,13 +24,13 @@ from ghae import\
 sp_remove(_REPO_ROOT)
 
 
-def _load_whole_json_file(json_path):
+def _load_json_file(json_path):
 	with json_path.open(mode=_MODE_R, encoding=_ENCODING_UTF8) as json_file:
 		return json.load(json_file)
 
 
 def test_error_detection_valid_request():
-	response_data = _load_whole_json_file(
+	response_data = _load_json_file(
 		_LOCAL_DIR/"response_to_valid_request.json")
 
 	# Success if GitHubApiError is not raised.
@@ -38,7 +38,7 @@ def test_error_detection_valid_request():
 
 
 def test_error_detection_erroneous_request():
-	response_data = _load_whole_json_file(
+	response_data = _load_json_file(
 		_LOCAL_DIR/"response_to_erroneous_request.json")
 
 	with pytest.raises(GitHubApiError) as except_info:


### PR DESCRIPTION
The new function `sp_prepend` allows to import `ghae` in the test module. Since only the tests need `syspathmodif`, publishing a new version of `ghae` is pointless.